### PR TITLE
Import fixed filelist.sh from Space Game RPX branch

### DIFF
--- a/filelist.sh
+++ b/filelist.sh
@@ -7,24 +7,14 @@ outFile="./src/resources/filelist.h"
 count_old=$(cat $outFile 2>/dev/null | tr -d '\n\n' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
 
 count=0
-if [[ $OSTYPE == darwin* ]];
-then
 
-for i in $(gfind ./data/images/ ./data/sounds/ ./data/fonts/ -maxdepth 1 -type f  \( ! -printf "%f\n" \) | sort -f)
+for i in $(find ./data/images/ ./data/sounds/ ./data/fonts/ -maxdepth 1 -type f)  #\( ! -printf "%f\n" \) | sort -f)
 do
 	files[count]=$i
 	count=$((count+1))
 done
 
-else
-
-for i in $(find ./data/images/ ./data/sounds/ ./data/fonts/ -maxdepth 1 -type f  \( ! -printf "%f\n" \) | sort -f)
-do
-	files[count]=$i
-	count=$((count+1))
-done
-
-fi
+#fi
 
 if [ "$count_old" != "$count" ] || [ ! -f $outFile ]
 then
@@ -41,22 +31,35 @@ cat <<EOF > $outFile
  ****************************************************************************/
 #ifndef _FILELIST_H_
 #define _FILELIST_H_
-
 typedef struct _RecourceFile
 {
-	const char          *filename;
-	const unsigned char *DefaultFile;
+	const char *filename;
+	const unsigned char   *DefaultFile;
 	const unsigned int  &DefaultFileSize;
-	unsigned char	    *CustomFile;
-	unsigned int        CustomFileSize;
+	unsigned char		   *CustomFile;
+	unsigned int		    CustomFileSize;
 } RecourceFile;
-
 EOF
 
 for i in ${files[@]}
 do
 	filename=${i%.*}
 	extension=${i##*.}
+
+  # For some reason, macOS and other Darwin-based operating systems contain a
+  # find untility that outputs full file paths instead of singular file names.
+  # To prevent this from screwing our program, we will remove the paths from the
+  # entries returned by the above loop if we are running on a Darwin platform.
+  if [[ $OSTYPE == darwin* ]]; then
+	if [[ ${filename:0:15} == ./data/sounds// ]]; then
+	  filename=${filename:15}
+	elif [[ ${filename:0:15} == ./data/images// ]]; then
+	  filename=${filename:15}
+	elif [[ ${filename:0:14} == ./data/fonts// ]]; then
+	  filename=${filename:14}
+	fi
+  fi
+
 	echo 'extern const unsigned char '$filename'_'$extension'[];' >> $outFile
 	echo 'extern const unsigned int '$filename'_'$extension'_size;' >> $outFile
 	echo '' >> $outFile
@@ -69,7 +72,19 @@ for i in ${files[@]}
 do
 	filename=${i%.*}
 	extension=${i##*.}
-	echo -e '\t{"'$i'", '$filename'_'$extension', '$filename'_'$extension'_size, NULL, 0},' >> $outFile
+
+  # See above for documentation on what this does.
+  if [[ $OSTYPE == darwin* ]]; then
+	if [[ ${filename:0:15} == ./data/sounds// ]]; then
+	  filename=${filename:15}
+	elif [[ ${filename:0:15} == ./data/images// ]]; then
+	  filename=${filename:15}
+	elif [[ ${filename:0:14} == ./data/fonts// ]]; then
+	  filename=${filename:14}
+	fi
+  fi
+
+	echo -e '\t{"'$filename'.'$extension'", '$filename'_'$extension', '$filename'_'$extension'_size, NULL, 0},' >> $outFile
 done
 
 echo -e '\t{NULL, NULL, 0, NULL, 0}' >> $outFile


### PR DESCRIPTION
The filelist.sh generator was broken on macOS, because whoever developed it (not naming anyone) seemed to think that instead of using "find" that Macs used "gfind." But "gfind" doesn't exist, at least in macOS Sierra.

The macOS "find" utility outputs full file paths rather than file names, so I cut them out manually. See the source for more details.

This was committed to the Space Game RPX branch in early January, and I meant to spread the word about this back then, but never did.